### PR TITLE
フロントでCIが落ちないようにするため、全角スペースを削除

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -560,7 +560,7 @@ components:
           readOnly: true
         name:
           type: "string"
-          example: "小説　天気の子"
+          example: "小説 天気の子"
         isTrapItem:
           $ref: "#/components/schemas/isEquipment"
           example: 0


### PR DESCRIPTION
動作が明らかなためそのままマージ