### PR TITLE
security: サプライチェーンハードニング対応（提案・自動生成）

### DIFF
--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: mariadb:11.5.2
+    image: mariadb:11.5.2@sha256:2d50fe0f77dac919396091e527e5e148a9de690e58f32875f113bef6506a17f5
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: booq-test


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> CI／サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・CI が通るかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。不要なものは部分的に revert／close いただいて構いません。

traPtitech org 全体のセキュリティ監査に基づく提案です。

## 適用した変更

### ✅ Docker ベースイメージを digest 固定（1 箇所）
信頼できる発行元（Docker 公式 / distroless / ghcr.io/traPtitech 等）の可変タグに `@sha256:...` を付与しました。
- `mariadb:11.5.2`（`docker/test/docker-compose.yml`）

## 確認のお願い
- [ ] CI が通ることを確認した

## 参考
- SHA pinning: [pinact](https://github.com/suzuki-shunsuke/pinact) ／ Dependabot（`github-actions`）・Renovate（`helpers:pinGitHubActionDigests`）でも自動更新できます
- [Docker Hardened Images](https://www.docker.com/ja-jp/products/hardened-images/)

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。